### PR TITLE
Adding hashed account ID to requests to fix bad request responses

### DIFF
--- a/custom_components/librelink/__init__.py
+++ b/custom_components/librelink/__init__.py
@@ -45,11 +45,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     # Then getting the token. This token is a long life token, so initializaing at HA start up is enough
-    sessionToken = await myLibrelinkLogin.async_get_token()
+    # Also getting the account id is important with the updated API
+    sessionToken, accountId = await myLibrelinkLogin.async_get_token()
 
     # The retrieved token will be used to initiate the coordinator which will be used to update the data on a regular basis
     myLibrelinkClient = LibreLinkApiClient(
         sessionToken,
+        accountId,
         session=async_get_clientsession(hass),
         base_url=BASE_URL_LIST.get(entry.data[COUNTRY]),
     )

--- a/custom_components/librelink/api.py
+++ b/custom_components/librelink/api.py
@@ -36,7 +36,7 @@ class LibreLinkApiClient:
         """Sample API Client."""
         self._token = token
         # Since only the hashed account id is required in later request, already hash it here 
-        self._hashedAccountId = hashlib.sha256(accountId).hexdigest()
+        self._hashedAccountId = hashlib.sha256(accountId.encode('utf-8')).hexdigest()
         self._session = session
         self.connection_url = base_url + CONNECTION_URL
 

--- a/custom_components/librelink/api.py
+++ b/custom_components/librelink/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import socket
+import hashlib
 
 import aiohttp
 
@@ -30,10 +31,12 @@ class LibreLinkApiClient:
     """
 
     def __init__(
-        self, token: str, base_url: str, session: aiohttp.ClientSession
+        self, token: str, accountId: str, base_url: str, session: aiohttp.ClientSession
     ) -> None:
         """Sample API Client."""
         self._token = token
+        # Since only the hashed account id is required in later request, already hash it here 
+        self._hashedAccountId = hashlib.sha256(accountId).hexdigest()
         self._session = session
         self.connection_url = base_url + CONNECTION_URL
 
@@ -48,6 +51,7 @@ class LibreLinkApiClient:
                 "version": VERSION_APP,
                 "Application": APPLICATION,
                 "Authorization": "Bearer " + self._token,
+                "Account-Id": self._hashedAccountId
             },
             data={},
         )
@@ -166,8 +170,9 @@ class LibreLinkApiLogin:
             )
 
         monToken = reponseLogin["data"]["authTicket"]["token"]
+        accountId = reponseLogin["data"]["user"]["id"]
 
-        return monToken
+        return monToken, accountId
 
 
 ################################################################

--- a/custom_components/librelink/const.py
+++ b/custom_components/librelink/const.py
@@ -38,7 +38,7 @@ BASE_URL_LIST = {
     "United States": "https://api-us.libreview.io",
 }
 PRODUCT = "llu.android"
-VERSION_APP = "4.7"
+VERSION_APP = "4.15"
 APPLICATION = "application/json"
 GLUCOSE_VALUE_ICON = "mdi:diabetes"
 GLUCOSE_TREND_ICON = [


### PR DESCRIPTION
For me, the integration didn't work as the API now requires the hashed account ID to be send with the other request. 
This PR adds this functionality by obtaining and hashing the account ID from the login request, when the Bearer token is also obtained. I also bumped the version, because with 4.9 the API responds that it doesn't support that version any longer.